### PR TITLE
fix(db): support current player charms schemas

### DIFF
--- a/prisma/migrations/20231205053917_prepare_player_charms_index/migration.sql
+++ b/prisma/migrations/20231205053917_prepare_player_charms_index/migration.sql
@@ -1,0 +1,49 @@
+-- Existing server schemas can identify the player with either `player_guid` or `player_id`.
+-- Create the shared index before the legacy squash so its name-based idempotency check works for both layouts.
+-- Some newer schemas omit `player_misc`, which the application migration still exposes and indexes.
+CREATE TABLE IF NOT EXISTS `player_misc` (
+    `player_id` INTEGER NOT NULL,
+    `info` BLOB NOT NULL
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+SET @player_charms_key_column = (
+    SELECT CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME = 'player_charms'
+                AND COLUMN_NAME = 'player_guid'
+        ) THEN 'player_guid'
+        WHEN EXISTS (
+            SELECT 1
+            FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME = 'player_charms'
+                AND COLUMN_NAME = 'player_id'
+        ) THEN 'player_id'
+        ELSE NULL
+    END
+);
+
+SET @player_charms_index_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'player_charms'
+        AND INDEX_NAME = 'player_charms_unique'
+);
+
+SET @player_charms_index_ddl = IF(
+    @player_charms_key_column IS NOT NULL AND @player_charms_index_exists = 0,
+    CONCAT(
+        'ALTER TABLE `player_charms` ADD UNIQUE INDEX `player_charms_unique` (`',
+        @player_charms_key_column,
+        '`)'
+    ),
+    'SELECT 1'
+);
+
+PREPARE player_charms_index_statement FROM @player_charms_index_ddl;
+EXECUTE player_charms_index_statement;
+DEALLOCATE PREPARE player_charms_index_statement;


### PR DESCRIPTION
Adds a compatibility migration for existing server databases whose `player_charms` table uses `player_id` instead of the legacy `player_guid`, preventing Prisma P3018 / database error 1072 while preserving support for older schemas.

## Fixes

- Detect whether `player_charms` identifies players through `player_guid` or `player_id`.
- Create `player_charms_unique` against the column that actually exists before the legacy 0.2.0 squash runs.
- Restore the empty `player_misc` compatibility table when newer server schemas omit it, preventing the squash from failing at its next index operation.
- Keep the published squash migration unchanged, avoiding a checksum change for databases where it was already applied.
- Allow an already failed deployment to recover by marking `20231205053918_squashed_migrations_0_2_0` rolled back and running `prisma migrate deploy` again.

## Tests/Validation

- Reproduced the original P3018 with MariaDB 11.4 loaded from a current server schema: query 32 failed because `player_guid` did not exist.
- Recovered that failed state with `prisma migrate resolve --rolled-back 20231205053918_squashed_migrations_0_2_0`; all remaining migrations then applied successfully.
- Confirmed `player_charms_unique` targets `player_id` on the current schema.
- Replayed the full migration history from an empty database and confirmed the same index targets legacy `player_guid`.
- Applied the new compatibility migration to a database where all six original migrations had already succeeded.
- Repeated `prisma migrate deploy` in every final state and confirmed there were no pending migrations or unresolved failures.
- `git diff --check` passed.
- A full application build was not run because this change is isolated to SQL migration compatibility.